### PR TITLE
Ajustes iniciales sobre bot ChatGPT

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ client.on('message', async (channel, tags, message, self) => {
 
   if (isChosen && isLongMessage) {
     const { personality, total_tokens, content } = await askGPT(message)
+    if (personality === "error" || total_tokens === 0) {
+      return
+    }
+
     client.say(channel, `@${username}: ` + personality + ' -> ' + content)
     console.log(` ${displayName}: ${message}`)
     console.log(`personalidad: ${personality} respuesta: ${content}`)

--- a/modules/gpt.js
+++ b/modules/gpt.js
@@ -4,12 +4,12 @@ import { getPersonality } from './getPersonality.js'
 
 dotenv.config({ path: '../.env' })
 
-export const askGPT = async message => {
-  const KEY_GPT = process.env.KEY_GPT
-  const MAX_CHARACTERS = 100
-  const MODEL = 'gpt-3.5-turbo'
-  const API_URL = 'https://api.openai.com/v1/chat/completions'
+const KEY_GPT = process.env.KEY_GPT
+const MAX_CHARACTERS = 100
+const MODEL = 'gpt-3.5-turbo'
+const API_URL = 'https://api.openai.com/v1/chat/completions'
 
+export const askGPT = async message => {
   const cleanMessage = message.replaceAll(`"`, "'")
   const { personality, context } = getPersonality()
 


### PR DESCRIPTION
En este PR, van 2 ajustes sobre el código inicial del bot ia4

- Se mueven líneas de variables constantes requeridas por el módulo `gpt`, se ponen en la parte superior, para que no sean creadas cada vez que se llama al módulo
- Se añade `early return` sobre el evento `message` de tmijs, cuando la respuesta de GPT es incorrecta, para prevenir que envíe un mensaje por el chat


🌹